### PR TITLE
Fix showAll toggle and relax saving constraints

### DIFF
--- a/backend/routes/projects.py
+++ b/backend/routes/projects.py
@@ -563,9 +563,6 @@ def add_segmentations(project_id, data_id, segmentation_id=None):
 
         data = Data.query.filter_by(id=data_id, project_id=project_id).first()
 
-        if project.allow_all_users == False and request_user != data.assigned_user:
-            return jsonify(message="Unauthorized access!"), 401
-
         segmentation = generate_segmentation(
             data_id=data_id,
             project_id=project.id,

--- a/frontend/src/pages/data.js
+++ b/frontend/src/pages/data.js
@@ -114,7 +114,7 @@ class Data extends React.Component {
             {isAdmin && (
               <label>
                 <input type="checkbox" checked={showAll} onChange={(event) => {
-                  window.location = this.prepareUrl(projectId, prevPage, active, event.currentTarget.checked);
+                  window.location = this.prepareUrl(projectId, page, active, event.currentTarget.checked);
                 }} />
                 {' '}
                 Show data for all users


### PR DESCRIPTION
Two fixes:

1. Fix page decreasing when toggling the "show all" checkbox added previously
2. Relax saving constraints
   
   So far making changes to other user's assignments was only possible with `allow_all_users` flag. This flag is not very safe though because anyone with an account could enumerate predictable data ids. Explicit list of people for each project is safer because each new user needs to be manually added.
   
   But on the other hand, we want to allow correcting other's work _within a given project_. For that we can relax the permission check slightly. Few lines above the removed part there's already a check whether the user is part of the project and this should be enough for our purposes.